### PR TITLE
Make BaseLazy and BaseProvider public to fix compilation warning

### DIFF
--- a/Sources/BaseLazy.swift
+++ b/Sources/BaseLazy.swift
@@ -7,7 +7,7 @@
 //
 
 
-internal class BaseThreadSaveLazy<Value> {
+public class BaseThreadSaveLazy<Value> {
 
   /// `true` if `self` was previously made.
   public var wasMade: Bool {

--- a/Sources/BaseProvider.swift
+++ b/Sources/BaseProvider.swift
@@ -7,7 +7,7 @@
 //
 
 
-internal class BaseProvider<Value> {
+public class BaseProvider<Value> {
 
   /// The value for `self`.
   ///


### PR DESCRIPTION
public inheritance from internal class will cause compilation warning in swift 4.2