### PR TITLE
Add Linux support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,6 @@ import PackageDescription
 
 let package = Package(
   name: "SwiftLazy",
-  platforms: [.iOS(.v13), .watchOS(.v8), .macOS(.v10_15), .tvOS(.v13)],
   products: [.library(name: "SwiftLazy", targets: ["SwiftLazy"])],
   targets: [.target(name: "SwiftLazy", dependencies: [])]
 )

--- a/Sources/SwiftLazy/BaseLazy.swift
+++ b/Sources/SwiftLazy/BaseLazy.swift
@@ -6,6 +6,13 @@
 //  Copyright © 2018 Alexander Ivlev. All rights reserved.
 //
 
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#elseif canImport(Musl)
+import Musl
+#endif
 import Dispatch
 
 public class BaseThreadSaveLazy<Value>: @unchecked Sendable {


### PR DESCRIPTION
- Remove `platforms` restriction from Package.swift (was Apple-only). And by that time iOS v13 and according Apple OSes are 7 years old so quite safe to assume people will have newer OSes
- Add platform-conditional imports for pthread types in BaseLazy.swift (Darwin/Glibc/Musl) so `pthread_rwlock_t` resolves on Linux